### PR TITLE
added missing view.focus() call

### DIFF
--- a/client/panel.js
+++ b/client/panel.js
@@ -23,6 +23,8 @@ function showAuthPanel() {
 
     showCursor(true);
     alt.toggleGameControls(false);
+
+    view.focus();
 }
 
 function exitAuthPanel() {


### PR DESCRIPTION
I raised an issue a few days ago. Yes, I had the event listeners in  abad place, but I also realized this one line was the real cause of the webview not being focused. 

I tried it out, this way the view gets focused, and I can type in the fields and click on the buttons.
Cheers!